### PR TITLE
Fix  state.lastItemOrNull() might return the second last query data that is misleading.

### DIFF
--- a/app/src/main/java/io/husayn/paging_library_sample/data/PokemonDao.java
+++ b/app/src/main/java/io/husayn/paging_library_sample/data/PokemonDao.java
@@ -11,14 +11,19 @@ import java.util.List;
 @Dao
 public interface PokemonDao {
 
-  @Query("SELECT * FROM pokemon  ORDER BY id DESC")
-  PagingSource<Integer, Pokemon> allByDesc();
-
   @Query("SELECT * FROM pokemon ORDER BY id ASC")
   PagingSource<Integer, Pokemon> allByAsc();
 
   @Query("SELECT * FROM pokemon  WHERE name like '%' || :name || '%' ORDER BY id ASC")
   PagingSource<Integer, Pokemon> queryBy(String name);
+
+  @Nullable
+  @Query("SELECT * FROM pokemon WHERE name like '%' || :name || '%'  ORDER BY id DESC")
+  Pokemon lastItemOrNull(String name);
+
+  @Nullable
+  @Query("SELECT * FROM pokemon ORDER BY id DESC")
+  Pokemon lastItemOrNull();
 
   @VisibleForTesting()
   @Query("SELECT COUNT(*) FROM pokemon")

--- a/app/src/main/java/io/husayn/paging_library_sample/listing/ExampleRemoteMediator.java
+++ b/app/src/main/java/io/husayn/paging_library_sample/listing/ExampleRemoteMediator.java
@@ -37,7 +37,7 @@ class ExampleRemoteMediator extends RxRemoteMediator<Integer, Pokemon> {
       case REFRESH:
         return refresh(loadType);
       case APPEND:
-        return append(loadType, state);
+        return append(state);
       case PREPEND:
       default:
         return ignorePrepend();
@@ -73,13 +73,13 @@ class ExampleRemoteMediator extends RxRemoteMediator<Integer, Pokemon> {
    * networkService is only valid for initial load. If lastItem is null it means no items were
    * loaded after the initial ø REFRESH and there are no more items to load.
    */
-  private Single<MediatorResult> append(LoadType loadType, PagingState<Integer, Pokemon> state) {
-    Timber.w("tonny append :%s", loadType);
-    Pokemon lastItem = state.lastItemOrNull();
+  private Single<MediatorResult> append(PagingState<Integer, Pokemon> state) {
+    Pokemon lastItem = pokemonRepo.lastItemOrNull(query);
+    Timber.w("tonny append with query:%s, last_item:%s", query, lastItem);
     if (lastItem == null) {
       return Single.just(new MediatorResult.Success(true));
     } else {
-      return execute(nextPagingRequest(query, lastItem), loadType);
+      return execute(nextPagingRequest(query, lastItem), LoadType.APPEND);
     }
   }
 

--- a/app/src/main/java/io/husayn/paging_library_sample/listing/PokemonRepo.java
+++ b/app/src/main/java/io/husayn/paging_library_sample/listing/PokemonRepo.java
@@ -82,4 +82,13 @@ public class PokemonRepo {
       }
     }
   }
+
+  /** Inspired from https://stackoverflow.com/a/66814196/4068957 */
+  @Nullable
+  public Pokemon lastItemOrNull(PagingQuery query) {
+    String name = query.searchKey();
+    return name == null
+        ? pokemonDao.lastItemOrNull()
+        : pokemonDao.lastItemOrNull(query.searchKey());
+  }
 }


### PR DESCRIPTION
Pay attention to key word : **Weepinbell** and **Weezing**.

The last item was suppose to be **Weezing**. Instead, it is using the last last item, which is **Weepinbell**.


2021-11-13 01:00:18.104 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=69, name='Bellsprout'}
2021-11-13 01:00:18.105 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=70, name='**Weepinbell**'}
2021-11-13 01:00:18.106 10069-10069/io.husayn.paging_library_sample I/EndOfPagingMapper: tonny endOfPaging:false, requested:10, responded:10
2021-11-13 01:00:19.182 10069-10069/io.husayn.paging_library_sample W/ExampleRemoteMediator: tonny refresh :REFRESH



2021-11-13 01:00:19.182 10069-10069/io.husayn.paging_library_sample W/ExampleRemoteMediator: tonny refresh :REFRESH
2021-11-13 01:00:19.185 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny flushDbData
2021-11-13 01:00:19.193 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny delete
2021-11-13 01:00:19.198 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny insertAll :10
2021-11-13 01:00:19.205 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=12, name='Butterfree'}
2021-11-13 01:00:19.210 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=13, name='Weedle'}
2021-11-13 01:00:19.213 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=15, name='Beedrill'}
2021-11-13 01:00:19.222 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=31, name='Nidoqueen'}
2021-11-13 01:00:19.229 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=70, name='**Weepinbell**'}
2021-11-13 01:00:19.232 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=71, name='Victreebel'}
2021-11-13 01:00:19.241 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=86, name='Seel'}
2021-11-13 01:00:19.248 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=96, name='Drowzee'}
2021-11-13 01:00:19.258 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=106, name='Hitmonlee'}
2021-11-13 01:00:19.261 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=110, name='**Weezing**'}
2021-11-13 01:00:19.267 10069-10069/io.husayn.paging_library_sample I/EndOfPagingMapper: tonny endOfPaging:false, requested:10, responded:10
2021-11-13 01:00:19.291 10069-10069/io.husayn.paging_library_sample W/ExampleRemoteMediator: tonny Prepend LoadType ignored
2021-11-13 01:00:19.298 10069-10069/io.husayn.paging_library_sample W/ExampleRemoteMediator: tonny append :APPEND
2021-11-13 01:00:19.309 10069-10069/io.husayn.paging_library_sample I/OffsetHelper: tonny offset loaded count:5, query:ee, last item:Pokemon{id=70, name='**Weepinbell**'}
2021-11-13 01:00:19.316 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny flushDbData
2021-11-13 01:00:19.319 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny insertAll :7
2021-11-13 01:00:19.334 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny skipped existing pokemon :Pokemon{id=71, name='Victreebel'}
2021-11-13 01:00:19.346 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny skipped existing pokemon :Pokemon{id=86, name='Seel'}
2021-11-13 01:00:19.351 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny skipped existing pokemon :Pokemon{id=96, name='Drowzee'}
2021-11-13 01:00:19.355 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny skipped existing pokemon :Pokemon{id=106, name='Hitmonlee'}
2021-11-13 01:00:19.365 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny skipped existing pokemon :Pokemon{id=110, name='Weezing'}
2021-11-13 01:00:19.368 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=118, name='Goldeen'}
2021-11-13 01:00:19.372 10069-10069/io.husayn.paging_library_sample W/PokemonRepo: tonny inserted new pokemon :Pokemon{id=133, name='Eevee'}
2021-11-13 01:00:19.377 10069-10069/io.husayn.paging_library_sample I/EndOfPagingMapper: tonny endOfPaging:true, requested:10, responded:7
