### PR TITLE
Change PagingConfig#enablePlaceholders to true to  stop the recycler view from flinching when PagingData is submitted.

### DIFF
--- a/app/src/main/java/io/husayn/paging_library_sample/listing/MainActivity.java
+++ b/app/src/main/java/io/husayn/paging_library_sample/listing/MainActivity.java
@@ -220,7 +220,9 @@ public class MainActivity extends AppCompatActivity
     @ActivityScope
     @Provides
     public static PagingConfig androidPagingConfig() {
-      return new PagingConfig(PAGE_SIZE, PREFETCH_DISTANCE, false, INITIAL_SIZE);
+      // Must enablePlaceholders to stop the recycler view from flinching when PagingData is
+      // submitted.
+      return new PagingConfig(PAGE_SIZE, PREFETCH_DISTANCE, true, INITIAL_SIZE);
     }
 
     @Binds


### PR DESCRIPTION
This is just one of the trickiest area in working with paging library. While the change of this pull request is just one line by turning `PagingConfig#enablePlaceholders` from `false` to `true`, it results in huge difference.

Because as a consumer of this library, I have no idea this could fix it and I had tried to tune around the thread related code, which almost crushed my soul as the wrong direction resulted me making all of irrelevant changes and refactors, to no prevail. Of course. 
Luckily, I randomly change this line of code and get it running smoothly. Then I reverted all changes except this one line of code and it turned out to be okay. Hence, this is where I am, writing this pull request summary.

For more details between the actual behavior of these two line of changes, please refer to the following two video. One is recorded with the flag `enablePlaceholders` as `false`, which is making the UI unpredictable. 

https://user-images.githubusercontent.com/8612724/141720575-2a69eb9d-e5f0-4ddb-bd96-2877c8544848.mp4

And the other is all good with predictable animation. 

https://user-images.githubusercontent.com/8612724/141720637-3f6f1f18-209e-44ad-a126-53e8db292b81.mp4 


